### PR TITLE
Politician card added

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [ignore]
-/node_modules
+<PROJECT_ROOT>/node_modules/config-chain/*
 [include]
 
 [libs]

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,10 @@
 import { configure } from '@kadira/storybook';
 
+
+const req = require.context('../src/Components', true, /.stories.js$/);
+
 function loadStories() {
-  require('../src/stories');
+  req.keys().forEach((filename) => req(filename));
 }
 
 configure(loadStories, module);

--- a/src/Components/PoliticianCard/index.js
+++ b/src/Components/PoliticianCard/index.js
@@ -1,0 +1,36 @@
+/* @flow */
+import React from 'react';
+import { Card, CardActions, CardHeader, CardText } from 'material-ui/Card';
+import LinearProgress from 'material-ui/LinearProgress';
+import PromiseList from '../PromiseList';
+import type { PromiseType } from '../PromiseList';
+
+export type Props = {
+  name: string,
+  party: string,
+  progress: number,
+  promises: Array<PromiseType>,
+};
+
+const PoliticianCard = (props: Props) => {
+  const { name, party, progress, promises } = props;
+  return (
+    <Card>
+      <CardHeader
+        title={name}
+        subtitle={party}
+        actAsExpander={true}
+        showExpandableButton={true}
+        avatar="http://lorempixel.com/200/200/"
+      >
+        {progress}% - {party}
+        <LinearProgress mode="determinate" value={progress} />
+      </CardHeader>
+      <CardText expandable={true}>
+        <PromiseList promises={promises} />
+      </CardText>
+    </Card>
+  );
+};
+
+export default PoliticianCard;

--- a/src/Components/PoliticianCard/stories/PoliticianCard.stories.js
+++ b/src/Components/PoliticianCard/stories/PoliticianCard.stories.js
@@ -1,0 +1,30 @@
+/* @flow */
+import React from 'react';
+import { storiesOf, action, linkTo, addDecorator } from '@kadira/storybook';
+import { muiTheme } from 'storybook-addon-material-ui';
+import PoliticianCard from '../index';
+import type { PromiseType } from '../../PromiseList';
+
+const promises: Array<PromiseType> = [
+  {
+    id: 1,
+    title: 'Longer workdays',
+    fulfilled: false,
+  },
+  {
+    id: 2,
+    title: '3 day weekends',
+    fulfilled: true,
+  },
+];
+
+storiesOf('Politican Card', module)
+  .addDecorator(muiTheme())
+  .add('Default', () => (
+    <PoliticianCard
+      name="Bjarni Ben"
+      party="Framsokn"
+      progress={53}
+      promises={promises}
+    />
+  ));

--- a/src/Components/PromiseItem/index.js
+++ b/src/Components/PromiseItem/index.js
@@ -1,0 +1,22 @@
+/* @flow */
+import React from 'react';
+import { ListItem } from 'material-ui/List';
+import InCompleteIcon from 'material-ui/svg-icons/navigation/close';
+import CompleteIcon from 'material-ui/svg-icons/navigation/check';
+import { red500, green500 } from 'material-ui/styles/colors';
+
+export type Props = {
+  id: number,
+  title: string,
+  fulfilled: boolean,
+};
+
+const PromiseItem = (props: Props) => {
+  const { title, fulfilled } = props;
+  const icon = fulfilled
+    ? <CompleteIcon color={green500} />
+    : <InCompleteIcon color={red500} />;
+  return <ListItem primaryText={title} rightIcon={icon} />;
+};
+
+export default PromiseItem;

--- a/src/Components/PromiseItem/stories/PromiseItem.stories.js
+++ b/src/Components/PromiseItem/stories/PromiseItem.stories.js
@@ -1,0 +1,14 @@
+/* @flow */
+import React from 'react';
+import { storiesOf, action, linkTo, addDecorator } from '@kadira/storybook';
+import { muiTheme } from 'storybook-addon-material-ui';
+import PromiseItem from '../index';
+
+storiesOf('Promise Item', module)
+  .addDecorator(muiTheme())
+  .add('Unfulfilled promise', () => (
+    <PromiseItem id={1} title="Save the whales" fulfilled={false} />
+  ))
+  .add('Fulfilled promise', () => (
+    <PromiseItem id={1} title="Higher politician salary" fulfilled={true} />
+  ));

--- a/src/Components/PromiseList/index.js
+++ b/src/Components/PromiseList/index.js
@@ -1,0 +1,25 @@
+/* @flow */
+import React from 'react';
+import { List } from 'material-ui/List';
+import PromiseItem from '../PromiseItem';
+
+export type PromiseType = {
+  id: number,
+  title: string,
+  fulfilled: boolean,
+};
+
+export type Props = {
+  promises: Array<PromiseType>,
+};
+
+const PromiseList = (props: Props) => {
+  const { promises } = props;
+  const promiseList = promises.map(promise => (
+    <PromiseItem id={promise.id} title={promise.title} fulfilled={promise.fulfilled} />
+  ));
+
+  return <List> {promiseList} </List>;
+};
+
+export default PromiseList;

--- a/src/Components/PromiseList/stories/PromiseList.stories.js
+++ b/src/Components/PromiseList/stories/PromiseList.stories.js
@@ -1,0 +1,23 @@
+/* @flow */
+import React from 'react';
+import { storiesOf, action, linkTo, addDecorator } from '@kadira/storybook';
+import { muiTheme } from 'storybook-addon-material-ui';
+import PromiseList from '../index';
+import type { PromiseType } from '../index';
+
+const promises: Array<PromiseType> = [
+  {
+    id: 1,
+    title: 'Longer workdays',
+    fulfilled: false,
+  },
+  {
+    id: 2,
+    title: '3 day weekends',
+    fulfilled: true,
+  },
+];
+
+storiesOf('Promise List', module)
+  .addDecorator(muiTheme())
+  .add('Default', () => <PromiseList promises={promises} />);


### PR DESCRIPTION
Introduces a rough draft of Politican Card component.

This PR also contains PromiseList and PromiseItem as sub-components.

There is no functionality added, merely presentation.

Storybook look:
![politician-card](https://cloud.githubusercontent.com/assets/22854722/25313361/3cc51a1e-282d-11e7-94da-fc6656105e0c.gif)
