### PR TITLE
Relaxing test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 4
   - 6
 cache:
   directories:


### PR DESCRIPTION
No need to run on Node4. Server will be higher version.

Currently Travis is running unnecessary tests that return false-positive errors.
![screen shot 2017-06-04 at 19 52 39](https://cloud.githubusercontent.com/assets/22854722/26764056/9efb8e04-495f-11e7-8bb5-99f8b9a731fd.png)
