### PR TITLE
Redux promises

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+flow-typed

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
   "parser": "babel-eslint",
   "extends": [
-    "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:flowtype/recommended",
     "plugin:react/recommended",

--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,0 +1,98 @@
+// flow-typed signature: 8db7b853f57c51094bf0ab8b2650fd9c
+// flow-typed version: ab8db5f14d/react-redux_v5.x.x/flow_>=v0.30.x
+
+import type { Dispatch, Store } from 'redux'
+
+declare module 'react-redux' {
+
+  /*
+
+    S = State
+    A = Action
+    OP = OwnProps
+    SP = StateProps
+    DP = DispatchProps
+
+  */
+
+  declare type MapStateToProps<S, OP: Object, SP: Object> = (state: S, ownProps: OP) => SP | MapStateToProps<S, OP, SP>;
+
+  declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: Dispatch<A>, ownProps: OP) => DP) | DP;
+
+  declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (stateProps: SP, dispatchProps: DP, ownProps: OP) => P;
+
+  declare type Context = { store: Store<*, *> };
+
+  declare type StatelessComponent<P> = (props: P, context: Context) => ?React$Element<any>;
+
+  declare class ConnectedComponent<OP, P, Def, St> extends React$Component<void, OP, void> {
+    static WrappedComponent: Class<React$Component<Def, P, St>>;
+    getWrappedInstance(): React$Component<Def, P, St>;
+    static defaultProps: void;
+    props: OP;
+    state: void;
+  }
+
+  declare type ConnectedComponentClass<OP, P, Def, St> = Class<ConnectedComponent<OP, P, Def, St>>;
+
+  declare type Connector<OP, P> = {
+    (component: StatelessComponent<P>): ConnectedComponentClass<OP, P, void, void>;
+    <Def, St>(component: Class<React$Component<Def, P, St>>): ConnectedComponentClass<OP, P, Def, St>;
+  };
+
+  declare class Provider<S, A> extends React$Component<void, { store: Store<S, A>, children?: any }, void> { }
+
+  declare type ConnectOptions = {
+    pure?: boolean,
+    withRef?: boolean
+  };
+
+  declare type Null = null | void;
+
+  declare function connect<A, OP>(
+    ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
+  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+
+  declare function connect<A, OP>(
+    mapStateToProps: Null,
+    mapDispatchToProps: Null,
+    mergeProps: Null,
+    options: ConnectOptions
+  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+
+  declare function connect<S, A, OP, SP>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: Null,
+    mergeProps: Null,
+    options?: ConnectOptions
+  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+
+  declare function connect<A, OP, DP>(
+    mapStateToProps: Null,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    mergeProps: Null,
+    options?: ConnectOptions
+  ): Connector<OP, $Supertype<DP & OP>>;
+
+  declare function connect<S, A, OP, SP, DP>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    mergeProps: Null,
+    options?: ConnectOptions
+  ): Connector<OP, $Supertype<SP & DP & OP>>;
+
+  declare function connect<S, A, OP, SP, DP, P>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: Null,
+    mergeProps: MergeProps<SP, DP, OP, P>,
+    options?: ConnectOptions
+  ): Connector<OP, P>;
+
+  declare function connect<S, A, OP, SP, DP, P>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    mergeProps: MergeProps<SP, DP, OP, P>,
+    options?: ConnectOptions
+  ): Connector<OP, P>;
+
+}

--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -1,0 +1,109 @@
+// flow-typed signature: 86993bd000012d3e1ef10d757d16952d
+// flow-typed version: a165222d28/redux_v3.x.x/flow_>=v0.33.x
+
+declare module 'redux' {
+
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare type DispatchAPI<A> = (action: A) => A;
+  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+
+  declare type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D;
+    getState(): S;
+  };
+
+  declare type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Reducer<S, A>): void
+  };
+
+  declare type Reducer<S, A> = (state: S, action: A) => S;
+
+  declare type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
+
+  declare type Middleware<S, A, D = Dispatch<A>> =
+    (api: MiddlewareAPI<S, A, D>) =>
+      (next: D) => D;
+
+  declare type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  };
+
+  declare type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
+
+  declare function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+
+  declare function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
+
+  declare type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any> };
+
+  declare function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
+  declare function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
+
+  declare function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare function compose<A, B>(ab: (a: A) => B): (a: A) => B
+  declare function compose<A, B, C>(
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => C
+  declare function compose<A, B, C, D>(
+    cd: (c: C) => D,
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => D
+  declare function compose<A, B, C, D, E>(
+    de: (d: D) => E,
+    cd: (c: C) => D,
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => E
+  declare function compose<A, B, C, D, E, F>(
+    ef: (e: E) => F,
+    de: (d: D) => E,
+    cd: (c: C) => D,
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => F
+  declare function compose<A, B, C, D, E, F, G>(
+    fg: (f: F) => G,
+    ef: (e: E) => F,
+    de: (d: D) => E,
+    cd: (c: C) => D,
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => G
+  declare function compose<A, B, C, D, E, F, G, H>(
+    gh: (g: G) => H,
+    fg: (f: F) => G,
+    ef: (e: E) => F,
+    de: (d: D) => E,
+    cd: (c: C) => D,
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => H
+  declare function compose<A, B, C, D, E, F, G, H, I>(
+    hi: (h: H) => I,
+    gh: (g: G) => H,
+    fg: (f: F) => G,
+    ef: (e: E) => F,
+    de: (d: D) => E,
+    cd: (c: C) => D,
+    bc: (b: B) => C,
+    ab: (a: A) => B
+  ): (a: A) => I
+
+}

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import SignUpContainer from './Components/User/SignUpContainer';
 import LoginContainer from './Components/User/LoginContainer';
 import PartyContainer from './Components/Parties/Party';
 import PartyPromisesContainer from './Components/Parties/PartyPromises';
+import PromiseContainer from './Components/Promises/PromiseContainer';
 import DistrictContainer from './Components/Districts/DistrictContainer';
 
 injectTapEventPlugin();
@@ -31,6 +32,7 @@ class App extends Component {
             <Route path="/login" component={LoginContainer} />
             <Route path="/parties" component={PartyContainer} />
             <Route path="/party/:partyId" component={PartyPromisesContainer} />
+            <Route path="/promises" component={PromiseContainer} />
             <Route path="/sign-up" component={SignUpContainer} />
           </div>
         </Router>

--- a/src/Components/NavBar/index.js
+++ b/src/Components/NavBar/index.js
@@ -59,6 +59,11 @@ export class NavBar extends React.Component {
               Party
             </MenuItem>
           </NavLink>
+          <NavLink to="/promises" onClick={this.handleToggle} style={styles.link}>
+            <MenuItem>
+              Promises
+            </MenuItem>
+          </NavLink>
           <NavLink to="/districts" onClick={this.handleToggle} style={styles.link}>
             <MenuItem>
               Districts

--- a/src/Components/Politicians/Politicians/index.js
+++ b/src/Components/Politicians/Politicians/index.js
@@ -14,7 +14,6 @@ type ReduxProps = {
   politicians: ?Array<PoliticianType>,
   hasLoadedPoliticians: boolean,
   error: ?string,
-  fetchPromises: () => void,
   fetchPoliticians: () => void,
 };
 

--- a/src/Components/Politicians/Politicians/index.js
+++ b/src/Components/Politicians/Politicians/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import React from 'react';
 import { connect } from 'react-redux';
+import type { Connector } from 'react-redux';
 import PoliticianCard from '../PoliticianCard';
 import { promiseCompletionPercentage } from '../../../utils/promises';
 import { fetchPoliticians } from '../../../Stores/Politicians/actions';
@@ -64,4 +65,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Politicians);
+const connector: Connector<OwnProps, Props> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
+
+export default connector(Politicians);

--- a/src/Components/Promises/PromiseContainer/index.js
+++ b/src/Components/Promises/PromiseContainer/index.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/Components/Promises/PromiseContainer/index.js
+++ b/src/Components/Promises/PromiseContainer/index.js
@@ -1,19 +1,60 @@
 /* @flow */
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
+import type { Connector } from 'react-redux';
+import { fetchPromises } from '../../../Stores/Promises/actions';
+import { promisesLoaded } from '../../../Stores/Promises/selectors';
+import type { Dispatch, State, PromiseType } from '../../../types';
+import PromiseTable from '../PromiseTable';
+
+type OwnProps = {};
+
+type ReduxProps = {
+  promises: ?Array<PromiseType>,
+  hasLoadedPromises: boolean,
+  error: ?string,
+  fetchPromises: () => void,
+};
+
+type Props = OwnProps & ReduxProps;
 
 export class PromiseContainer extends React.Component {
-  state = {
-    promises: [],
-  };
+  props: Props;
+
+  componentDidMount() {
+    const { hasLoadedPromises } = this.props;
+    if (!hasLoadedPromises) {
+      this.props.fetchPromises();
+    }
+  }
 
   render() {
-    return (
-      <div>
-        hello
-      </div>
-    );
+    const { promises } = this.props;
+    if (!promises) return null;
+
+    return <PromiseTable promises={promises} />;
   }
 }
 
-export default PromiseContainer;
+const mapStateToProps = (state: State) => {
+  return {
+    error: state.promises.error,
+    hasLoadedPromises: promisesLoaded(state),
+    promises: state.promises.promises,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return {
+    fetchPromises: () => {
+      dispatch(fetchPromises());
+    },
+  };
+};
+
+const connector: Connector<OwnProps, Props> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
+
+export default connector(PromiseContainer);

--- a/src/Components/Promises/PromiseContainer/index.js
+++ b/src/Components/Promises/PromiseContainer/index.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+export class PromiseContainer extends React.Component {
+  state = {
+    promises: [],
+  };
+
+  render() {
+    return (
+      <div>
+        hello
+      </div>
+    );
+  }
+}
+
+export default PromiseContainer;

--- a/src/Components/Promises/PromiseTable/index.js
+++ b/src/Components/Promises/PromiseTable/index.js
@@ -51,7 +51,7 @@ const PromiseTable = (props: Props) => {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {promiseRows}lel
+        {promiseRows}
       </TableBody>
     </Table>
   );

--- a/src/Stores/Politicians/reducer.js
+++ b/src/Stores/Politicians/reducer.js
@@ -16,7 +16,7 @@ const initialState = {
 const politiciansReducer = (state: State = initialState, action: Action): State => {
   switch (action.type) {
     case 'POLITICIANS_LOAD':
-      return { ...state, loading: true, politicians: null };
+      return { ...state, loading: true, politicians: null, error: null };
     case 'POLITICIANS_LOAD_SUCCESS':
       return { ...state, loading: false, politicians: action.politicians };
     case 'POLITICIANS_LOAD_FAILURE':

--- a/src/Stores/Promises/__tests__/reducer.test.js
+++ b/src/Stores/Promises/__tests__/reducer.test.js
@@ -1,0 +1,51 @@
+/* @flow */
+import reducer from '../reducer';
+import { promises } from '../../../utils/testFixtures';
+
+describe('Promises reducer', () => {
+  it('should return initial state', () => {
+    expect(reducer(undefined, {})).toEqual({
+      error: null,
+      loading: false,
+      promises: null,
+    });
+  });
+
+  it('should clear data and set Loading', () => {
+    const action = {
+      type: 'PROMISES_LOAD',
+    };
+
+    expect(reducer(undefined, action)).toEqual({
+      error: null,
+      loading: true,
+      promises: null,
+    });
+  });
+
+  it('should error on fail', () => {
+    const action = {
+      type: 'PROMISES_LOAD_FAILURE',
+      error: 'Couldnt get promises',
+    };
+
+    expect(reducer(undefined, action)).toEqual({
+      error: 'Couldnt get promises',
+      loading: false,
+      promises: null,
+    });
+  });
+
+  it('should load data on success', () => {
+    const action = {
+      type: 'PROMISES_LOAD_SUCCESS',
+      promises,
+    };
+
+    expect(reducer(undefined, action)).toEqual({
+      error: null,
+      loading: false,
+      promises,
+    });
+  });
+});

--- a/src/Stores/Promises/__tests__/selectors.test.js
+++ b/src/Stores/Promises/__tests__/selectors.test.js
@@ -1,0 +1,108 @@
+/* @flow */
+
+import { promisesSelector } from '../selectors';
+import { initialState, politicians, promises } from '../../../utils/testFixtures';
+
+describe('Promises selector', () => {
+  it('loads initial state', () => {
+    expect(promisesSelector(initialState)).toEqual(null);
+  });
+
+  it('Returns null if politicians arent loaded', () => {
+    const loadedState = {
+      ...initialState,
+      promises: {
+        ...initialState.promises,
+        promises: [promises[0]],
+      },
+    };
+    expect(promisesSelector(loadedState)).toEqual(null);
+  });
+
+  it('Returns promises', () => {
+    // TODO use the enriched politician object
+    // const politician = {
+    //   name: 'Andrés Ingi Jónsson',
+    //   id: 1,
+    //   initials: 'AIJ',
+    //   districtNumber: 10,
+    //   party: {
+    //     name: 'Vinstri Hreyfingin - Grænt Framboð',
+    //     id: 3,
+    //     website: 'http://vg.is/',
+    //     created: '2017-04-25T17:41:28Z',
+    //     modified: '2017-04-25T17:41:28Z',
+    //   },
+    //   district: {
+    //     name: 'Reykjavik Norður’',
+    //     id: 1,
+    //     abbreviation: 'Reykv. N.',
+    //     created: '2017-04-25T17:41:28Z',
+    //     modified: '2017-04-25T17:41:28Z',
+    //   },
+    //   promises: [
+    //     {
+    //       name: 'Some title',
+    //       small_description: 'Another title',
+    //       long_description: 'Yet another title',
+    //       parliament: {
+    //         name: 'Test-Parliament',
+    //         id: 1,
+    //       },
+    //       id: 4,
+    //       created: '2017-06-06T19:36:10.404869Z',
+    //       modified: '2017-06-06T19:36:10.404898Z',
+    //       politician: 2,
+    //       party: 1,
+    //       fulfilled: false,
+    //     },
+    //     {
+    //       name: 'Raise taxes',
+    //       small_description: 'Short description',
+    //       long_description: 'long\ndescription\nexplaining the entire thing',
+    //       parliament: {
+    //         name: 'Test-Parliament',
+    //         id: 1,
+    //       },
+    //       id: 5,
+    //       created: '2017-06-06T19:38:33.526074Z',
+    //       modified: '2017-06-06T19:38:33.526105Z',
+    //       politician: 2,
+    //       party: 1,
+    //       fulfilled: false,
+    //     },
+    //   ],
+    // };
+    const politician = 2;
+    const combinedPromise = {
+      name: 'Some title',
+      small_description: 'Another title',
+      long_description: 'Yet another title',
+      parliament: {
+        name: 'Test-Parliament',
+        id: 1,
+      },
+      id: 4,
+      created: '2017-06-06T19:36:10.404869Z',
+      modified: '2017-06-06T19:36:10.404898Z',
+      politician: politician,
+      party: 1,
+      fulfilled: true,
+    };
+
+    const loadedState = {
+      ...initialState,
+      politicians: {
+        ...initialState.politicians,
+        politicians,
+      },
+      promises: {
+        ...initialState.promises,
+        promises: [promises[0]],
+      },
+    };
+
+    // expect(loadedState).toEqual({});
+    expect(promisesSelector(loadedState)).toEqual([combinedPromise]);
+  });
+});

--- a/src/Stores/Promises/actions.js
+++ b/src/Stores/Promises/actions.js
@@ -1,0 +1,31 @@
+/* @flow */
+import type { Dispatch, PromiseType } from '../../types';
+import { getPromises as apiGetPromises } from '../../utils/api';
+
+const getPromises = () => ({ type: 'PROMISES_LOAD' });
+
+const getPromisesSuccess = (promises: Array<PromiseType>) => ({
+  promises,
+  type: 'PROMISES_LOAD_SUCCESS',
+});
+
+const getPromisesFailure = (error: *) => ({
+  error,
+  type: 'PROMISES_LOAD_FAILURE',
+});
+
+export const fetchPromises = () => (dispatch: Dispatch) => {
+  dispatch(getPromises());
+
+  return apiGetPromises().then(
+    promises => dispatch(getPromisesSuccess(promises)),
+    error => dispatch(getPromisesFailure(error.message))
+  );
+};
+
+export default {
+  getPromises,
+  getPromisesSuccess,
+  getPromisesFailure,
+  fetchPromises,
+};

--- a/src/Stores/Promises/reducer.js
+++ b/src/Stores/Promises/reducer.js
@@ -1,0 +1,29 @@
+/* @flow */
+import type { PromiseType, Action } from '../../types';
+
+export type State = {
+  +promises: ?Array<PromiseType>,
+  +loading: boolean,
+  +error: *,
+};
+
+const initialState = {
+  promises: null,
+  loading: false,
+  error: null,
+};
+
+const promisesReducer = (state: State = initialState, action: Action): State => {
+  switch (action.type) {
+    case 'PROMISES_LOAD':
+      return { ...state, loading: true, promises: null };
+    case 'PROMISES_LOAD_SUCCESS':
+      return { ...state, loading: false, promises: action.promises };
+    case 'PROMISES_LOAD_FAILURE':
+      return { ...state, loading: false, error: action.error };
+    default:
+      return state;
+  }
+};
+
+export default promisesReducer;

--- a/src/Stores/Promises/reducer.js
+++ b/src/Stores/Promises/reducer.js
@@ -16,7 +16,7 @@ const initialState = {
 const promisesReducer = (state: State = initialState, action: Action): State => {
   switch (action.type) {
     case 'PROMISES_LOAD':
-      return { ...state, loading: true, promises: null };
+      return { ...state, loading: true, promises: null, error: null };
     case 'PROMISES_LOAD_SUCCESS':
       return { ...state, loading: false, promises: action.promises };
     case 'PROMISES_LOAD_FAILURE':

--- a/src/Stores/Promises/selectors.js
+++ b/src/Stores/Promises/selectors.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { State, PromiseType, PoliticianType } from '../../types';
+import type { State, PoliticianType } from '../../types';
 
 export const promisesSelector = (state: State) => {
   const promises = state.promises.promises;

--- a/src/Stores/Promises/selectors.js
+++ b/src/Stores/Promises/selectors.js
@@ -1,0 +1,13 @@
+/* @flow */
+import type { State, PromiseType, PoliticianType } from '../../types';
+
+export const promisesSelector = (state: State) => {
+  const promises = state.promises.promises;
+  const politicians: ?Array<PoliticianType> = state.politicians.politicians;
+
+  if (!politicians || !promises) return null;
+
+  return promises;
+};
+
+export const promisesLoaded = (state: State) => state.promises.promises !== null;

--- a/src/Stores/rootReducer.js
+++ b/src/Stores/rootReducer.js
@@ -1,9 +1,11 @@
 /* @flow */
 import { combineReducers } from 'redux';
 import PoliticiansReducer from './Politicians/reducer';
+import PromisesReducer from './Promises/reducer';
 
 const reducer = combineReducers({
   politicians: PoliticiansReducer,
+  promises: PromisesReducer,
 });
 
 export default reducer;

--- a/src/types.js
+++ b/src/types.js
@@ -14,7 +14,7 @@ export type PromiseType = {
   parliament: ParliamentType,
   created: string,
   modified: string,
-  politician: PoliticianIdType,
+  politician: *,
   party: PartyIdType,
   fulfilled: boolean,
 };
@@ -99,6 +99,10 @@ export type State = {
   politicians: {
     error: ?string,
     politicians: ?Array<PoliticianType>,
+  },
+  promises: {
+    error: ?string,
+    promises: ?Array<PromiseType>,
   },
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -98,10 +98,12 @@ type PromiseAction = Promise<Action>;
 export type State = {
   politicians: {
     error: ?string,
+    loading: boolean,
     politicians: ?Array<PoliticianType>,
   },
   promises: {
     error: ?string,
+    loading: boolean,
     promises: ?Array<PromiseType>,
   },
 };

--- a/src/utils/testFixtures.js
+++ b/src/utils/testFixtures.js
@@ -548,4 +548,9 @@ export const initialState: State = {
     error: null,
     loading: false,
   },
+  promises: {
+    promises: null,
+    error: null,
+    loading: false,
+  },
 };


### PR DESCRIPTION
## Status
**Ready**

## Description
Reduxing promises

Contains flowtypings for it as well :)

## Example | Screenshots
![screen shot 2017-08-15 at 20 46 15](https://user-images.githubusercontent.com/22854722/29330846-cda144d2-81fa-11e7-853f-135af82343f9.png)


## Testing
`yarn run check` will run Eslint and Flow for linting and static type checking.

Make sure you create promises before checking out the `PromiseTable` 
Can be done via http://localhost:3000/add-promise (remember to login first)
`yarn start` will fire up the server, navigate to http://localhost:3000/promises for a promise table.

Open [Redux-devtools](https://github.com/gaearon/redux-devtools) to explore the glorious state