### PR TITLE
Conditional render

### DIFF
--- a/src/Components/Utils/SnackBar/index.js
+++ b/src/Components/Utils/SnackBar/index.js
@@ -20,6 +20,9 @@ class SnackBar extends React.Component {
 
   render() {
     const { message, clearMessage } = this.props;
+    if (!message) {
+      return null;
+    }
 
     return (
       <MaterialSnackBar


### PR DESCRIPTION
message is marked required(but probably is not) on MaterialSnackbar. Only render if we have that prop

## Status
**Ready**

## Description
Gets rid of the following error message 
```
proxyConsole.js:56 Warning: Failed prop type: The prop message is marked as required in SnackbarBody, but its value is null.
    in SnackbarBody (created by WithWidth)
    in WithWidth (created by Snackbar)
    in div (created by Snackbar)
    in ClickAwayListener (created by Snackbar)
    in Snackbar (at index.js:25)
    in SnackBar (created by Connect(SnackBar))
    in Connect(SnackBar) (at App.js:30)
    in div (at App.js:28)
    in Router (created by BrowserRouter)
    in BrowserRouter (at App.js:27)
    in MuiThemeProvider (at App.js:26)
    in App (at index.js:10)
    in Provider (at index.js:9)
```