### PR TITLE
Subject -> promises v1

### DIFF
--- a/flow-typed/npm/reselect_v3.x.x.js
+++ b/flow-typed/npm/reselect_v3.x.x.js
@@ -1,0 +1,888 @@
+// flow-typed signature: 8128b319cd5e73384edca37a33fa76fc
+// flow-typed version: f0506e4101/reselect_v3.x.x/flow_>=v0.34.x <=v0.46.x
+
+declare module "reselect" {
+  declare type Selector<TState, TProps, TResult> = {
+    (state: TState, props: TProps, ...rest: any[]): TResult
+  };
+
+  declare type SelectorCreator = {
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      selector16: Selector<TState, TProps, T16>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>,
+        Selector<TState, TProps, T16>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2>(
+      selectors: [Selector<TState, TProps, T1>, Selector<TState, TProps, T2>],
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1>(
+      selector1: Selector<TState, TProps, T1>,
+      resultFunc: (arg1: T1) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1>(
+      selectors: [Selector<TState, TProps, T1>],
+      resultFunc: (arg1: T1) => TResult
+    ): Selector<TState, TProps, TResult>
+  };
+
+  declare type Reselect = {
+    createSelector: SelectorCreator,
+
+    defaultMemoize: <TFunc: Function>(
+      func: TFunc,
+      equalityCheck?: (a: any, b: any) => boolean
+    ) => TFunc,
+
+    createSelectorCreator: (
+      memoize: Function,
+      ...memoizeOptions: any[]
+    ) => SelectorCreator,
+
+    createStructuredSelector: <TState, TProps>(
+      inputSelectors: {
+        [k: string | number]: Selector<TState, TProps, any>
+      },
+      selectorCreator?: SelectorCreator
+    ) => Selector<TState, TProps, any>
+  };
+
+  declare var exports: Reselect;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@storybook/react": "3.0.0",
     "babel-eslint": "^7.2.1",
+    "deep-freeze": "^0.0.1",
     "enzyme": "^2.8.2",
     "eslint": "^3.19.0",
     "eslint-config-prettier": "^1.6.0",

--- a/src/Components/Promises/PromiseContainer/index.js
+++ b/src/Components/Promises/PromiseContainer/index.js
@@ -61,7 +61,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
   };
 };
 
-const connector: Connector<OwnProps, Props> = connect(
+const connector: Connector<OwnProps, ReduxProps> = connect(
   mapStateToProps,
   mapDispatchToProps
 );

--- a/src/Components/Promises/PromiseContainer/index.js
+++ b/src/Components/Promises/PromiseContainer/index.js
@@ -4,7 +4,10 @@ import { connect } from 'react-redux';
 import type { Connector } from 'react-redux';
 import { fetchPromises } from '../../../Stores/Promises/actions';
 import { linkSubjectToPromisesThunk } from '../../../Stores/Subjects/actions';
-import { promisesLoaded } from '../../../Stores/Promises/selectors';
+import {
+  promiseSubjectsSelector,
+  promisesLoaded,
+} from '../../../Stores/Promises/selectors';
 import type { Dispatch, State, PromiseType, PromiseId, SubjectId } from '../../../types';
 import PromiseTable from '../PromiseTable';
 
@@ -44,7 +47,7 @@ const mapStateToProps = (state: State) => {
   return {
     error: state.promises.error,
     hasLoadedPromises: promisesLoaded(state),
-    promises: state.promises.promises,
+    promises: promiseSubjectsSelector(state),
   };
 };
 

--- a/src/Stores/Promises/__tests__/selectors.test.js
+++ b/src/Stores/Promises/__tests__/selectors.test.js
@@ -1,78 +1,16 @@
 /* @flow */
 
-import { promisesSelector } from '../selectors';
+import deepFreeze from 'deep-freeze';
+import { promisesSelector, promiseSubjectsSelector } from '../selectors';
 import { initialState, politicians, promises } from '../../../utils/testFixtures';
+import type { Subject } from '../../../types';
 
 describe('Promises selector', () => {
   it('loads initial state', () => {
     expect(promisesSelector(initialState)).toEqual(null);
   });
 
-  it('Returns null if politicians arent loaded', () => {
-    const loadedState = {
-      ...initialState,
-      promises: {
-        ...initialState.promises,
-        promises: [promises[0]],
-      },
-    };
-    expect(promisesSelector(loadedState)).toEqual(null);
-  });
-
   it('Returns promises', () => {
-    // TODO use the enriched politician object
-    // const politician = {
-    //   name: 'Andrés Ingi Jónsson',
-    //   id: 1,
-    //   initials: 'AIJ',
-    //   districtNumber: 10,
-    //   party: {
-    //     name: 'Vinstri Hreyfingin - Grænt Framboð',
-    //     id: 3,
-    //     website: 'http://vg.is/',
-    //     created: '2017-04-25T17:41:28Z',
-    //     modified: '2017-04-25T17:41:28Z',
-    //   },
-    //   district: {
-    //     name: 'Reykjavik Norður’',
-    //     id: 1,
-    //     abbreviation: 'Reykv. N.',
-    //     created: '2017-04-25T17:41:28Z',
-    //     modified: '2017-04-25T17:41:28Z',
-    //   },
-    //   promises: [
-    //     {
-    //       name: 'Some title',
-    //       small_description: 'Another title',
-    //       long_description: 'Yet another title',
-    //       parliament: {
-    //         name: 'Test-Parliament',
-    //         id: 1,
-    //       },
-    //       id: 4,
-    //       created: '2017-06-06T19:36:10.404869Z',
-    //       modified: '2017-06-06T19:36:10.404898Z',
-    //       politician: 2,
-    //       party: 1,
-    //       fulfilled: false,
-    //     },
-    //     {
-    //       name: 'Raise taxes',
-    //       small_description: 'Short description',
-    //       long_description: 'long\ndescription\nexplaining the entire thing',
-    //       parliament: {
-    //         name: 'Test-Parliament',
-    //         id: 1,
-    //       },
-    //       id: 5,
-    //       created: '2017-06-06T19:38:33.526074Z',
-    //       modified: '2017-06-06T19:38:33.526105Z',
-    //       politician: 2,
-    //       party: 1,
-    //       fulfilled: false,
-    //     },
-    //   ],
-    // };
     const politician = 2;
     const combinedPromise = {
       name: 'Some title',
@@ -102,7 +40,90 @@ describe('Promises selector', () => {
       },
     };
 
-    // expect(loadedState).toEqual({});
     expect(promisesSelector(loadedState)).toEqual([combinedPromise]);
+  });
+
+  it('Returns promise with subjects objects', () => {
+    const politician = 2;
+    const testSubjects: Array<Subject> = [
+      {
+        id: 3,
+        created: 'yesterday',
+        description: 'Some descriptive description',
+        modified: 'today',
+        name: 'Lowering tax',
+        number: null,
+        parent: null,
+        parliament_session: 1,
+      },
+      {
+        id: 6,
+        created: 'today',
+        description: 'Another descriptive description',
+        modified: 'tomorrow',
+        name: 'Increase taxes',
+        number: null,
+        parent: null,
+        parliament_session: 1,
+      },
+    ];
+
+    const combinedPromise = {
+      name: 'Some title',
+      small_description: 'Another title',
+      long_description: 'Yet another title',
+      parliament: {
+        name: 'Test-Parliament',
+        id: 1,
+      },
+      id: 4,
+      created: '2017-06-06T19:36:10.404869Z',
+      modified: '2017-06-06T19:36:10.404898Z',
+      politician: politician,
+      party: 1,
+      fulfilled: true,
+      subjects: testSubjects,
+    };
+
+    const subjectsPromises = [
+      {
+        id: 1,
+        promise: 4,
+        subject: 3,
+        created: '2017-11-12T12:24:14.060672Z',
+        modified: '2017-11-12T12:24:14.060699Z',
+      },
+      {
+        id: 2,
+        promise: 4,
+        subject: 6,
+        created: '2017-11-12T12:24:14.060672Z',
+        modified: '2017-11-12T12:24:14.060699Z',
+      },
+    ];
+
+    const loadedState = {
+      ...initialState,
+      politicians: {
+        ...initialState.politicians,
+        politicians,
+      },
+      promises: {
+        ...initialState.promises,
+        promises: [promises[0]],
+      },
+      subjects: {
+        ...initialState.subjects,
+        subjects: testSubjects,
+      },
+      subjectsPromises: {
+        ...initialState.subjectsPromises,
+        subjectsPromises,
+      },
+    };
+
+    deepFreeze(loadedState);
+
+    expect(promiseSubjectsSelector(loadedState)).toEqual([combinedPromise]);
   });
 });

--- a/src/Stores/Promises/__tests__/selectors.test.js
+++ b/src/Stores/Promises/__tests__/selectors.test.js
@@ -118,7 +118,7 @@ describe('Promises selector', () => {
       },
       subjectsPromises: {
         ...initialState.subjectsPromises,
-        subjectsPromises,
+        data: subjectsPromises,
       },
     };
 

--- a/src/Stores/Promises/selectors.js
+++ b/src/Stores/Promises/selectors.js
@@ -12,7 +12,11 @@ export const promisesSelector = (state: State): ?Array<PromiseType> => {
   return promises;
 };
 
-export const promiseSubjectsSelector = createSelector(
+export const promiseSubjectsSelector: (
+  state: State
+) => ?Array<
+  PromiseType
+> = createSelector(
   promisesSelector,
   subjectsSelector,
   subjectsPromisesSelector,

--- a/src/Stores/Promises/selectors.js
+++ b/src/Stores/Promises/selectors.js
@@ -1,13 +1,34 @@
 /* @flow */
-import type { State, PoliticianType } from '../../types';
+import type { State, PromiseType } from '../../types';
+import { subjectsSelector } from '../Subjects/selectors';
+import { subjectsPromisesSelector } from '../SubjectsPromises/selectors';
+import { createSelector } from 'reselect';
 
-export const promisesSelector = (state: State) => {
+export const promisesSelector = (state: State): ?Array<PromiseType> => {
   const promises = state.promises.promises;
-  const politicians: ?Array<PoliticianType> = state.politicians.politicians;
 
-  if (!politicians || !promises) return null;
+  if (!promises) return null;
 
   return promises;
 };
 
+export const promiseSubjectsSelector = createSelector(
+  promisesSelector,
+  subjectsSelector,
+  subjectsPromisesSelector,
+  (promises, subjects, subjectsPromises) => {
+    if (!promises) {
+      return null;
+    }
+    return promises.map(promise => {
+      const links = subjectsPromises
+        ? subjectsPromises.filter(sP => sP.promise === promise.id)
+        : [];
+      const subs = links.map(
+        link => (subjects ? subjects.find(s => link.subject === s.id) : [])
+      );
+      return { ...promise, subjects: subs };
+    });
+  }
+);
 export const promisesLoaded = (state: State) => state.promises.promises !== null;

--- a/src/Stores/Promises/selectors.js
+++ b/src/Stores/Promises/selectors.js
@@ -4,13 +4,8 @@ import { subjectsSelector } from '../Subjects/selectors';
 import { subjectsPromisesSelector } from '../SubjectsPromises/selectors';
 import { createSelector } from 'reselect';
 
-export const promisesSelector = (state: State): ?Array<PromiseType> => {
-  const promises = state.promises.promises;
-
-  if (!promises) return null;
-
-  return promises;
-};
+export const promisesSelector = (state: State): ?Array<PromiseType> =>
+  state.promises.promises ? state.promises.promises : null;
 
 export const promiseSubjectsSelector: (
   state: State

--- a/src/Stores/Subjects/actions.js
+++ b/src/Stores/Subjects/actions.js
@@ -1,5 +1,11 @@
 /* @flow */
-import type { Dispatch, Subject, SubjectId, PromiseId } from '../../types';
+import type {
+  Dispatch,
+  Subject,
+  SubjectId,
+  PromiseId,
+  SubjectPromise,
+} from '../../types';
 import {
   getSubjects as apiGetSubjects,
   linkSubjectPromise as apiLinkSubjectPromise,
@@ -28,9 +34,9 @@ export const fetchSubjects = () => (dispatch: Dispatch) => {
 
 const linkSubjectPromise = () => ({ type: 'SUBJECT_PROMISE_LINK' });
 
-const linkSubjectPromiseSuccess = resp => ({
+const linkSubjectPromiseSuccess = (payload: SubjectPromise) => ({
   type: 'SUBJECT_PROMISE_LINK_SUCCESS',
-  resp,
+  payload,
 });
 
 const linkSubjectPromiseFailure = error => ({

--- a/src/Stores/Subjects/actions.js
+++ b/src/Stores/Subjects/actions.js
@@ -11,16 +11,24 @@ import {
   linkSubjectPromise as apiLinkSubjectPromise,
 } from '../../utils/api';
 
-const getSubjects = () => ({ type: 'SUBJECTS_LOAD' });
+export const ActionTypes = {
+  SUBJECTS_LOAD: 'SUBJECTS_LOAD',
+  SUBJECTS_LOAD_SUCCESS: 'SUBJECTS_LOAD_SUCCESS',
+  SUBJECTS_LOAD_FAILURE: 'SUBJECTS_LOAD_FAILURE',
+  SUBJECT_PROMISE_LINK: 'SUBJECT_PROMISE_LINK',
+  SUBJECT_PROMISE_LINK_SUCCESS: 'SUBJECT_PROMISE_LINK_SUCCESS',
+  SUBJECT_PROMISE_LINK_FAILURE: 'SUBJECT_PROMISE_LINK_FAILURE',
+};
+const getSubjects = () => ({ type: ActionTypes.SUBJECTS_LOAD });
 
 const getSubjectsSuccess = (subjects: Array<Subject>) => ({
   subjects,
-  type: 'SUBJECTS_LOAD_SUCCESS',
+  type: ActionTypes.SUBJECTS_LOAD_SUCCESS,
 });
 
 const getSubjectsFailure = (error: *) => ({
   error,
-  type: 'SUBJECTS_LOAD_FAILURE',
+  type: ActionTypes.SUBJECTS_LOAD_FAILURE,
 });
 
 export const fetchSubjects = () => (dispatch: Dispatch) => {
@@ -32,15 +40,15 @@ export const fetchSubjects = () => (dispatch: Dispatch) => {
   );
 };
 
-const linkSubjectPromise = () => ({ type: 'SUBJECT_PROMISE_LINK' });
+const linkSubjectPromise = () => ({ type: ActionTypes.SUBJECT_PROMISE_LINK });
 
 const linkSubjectPromiseSuccess = (payload: SubjectPromise) => ({
-  type: 'SUBJECT_PROMISE_LINK_SUCCESS',
+  type: ActionTypes.SUBJECT_PROMISE_LINK_SUCCESS,
   payload,
 });
 
 const linkSubjectPromiseFailure = error => ({
-  type: 'SUBJECT_PROMISE_LINK_FAILURE',
+  type: ActionTypes.SUBJECT_PROMISE_LINK_FAILURE,
   error,
 });
 

--- a/src/Stores/Subjects/reducer.js
+++ b/src/Stores/Subjects/reducer.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type { Subject, Action } from '../../types';
-
+import { ActionTypes } from './actions';
 export type State = {
   +subjects: ?Array<Subject>,
   +loading: boolean,
@@ -15,11 +15,11 @@ const initialState = {
 
 const subjectsReducer = (state: State = initialState, action: Action): State => {
   switch (action.type) {
-    case 'SUBJECTS_LOAD':
+    case ActionTypes.SUBJECTS_LOAD:
       return { ...state, loading: true, subjects: null, error: null };
-    case 'SUBJECTS_LOAD_SUCCESS':
+    case ActionTypes.SUBJECTS_LOAD_SUCCESS:
       return { ...state, loading: false, subjects: action.subjects };
-    case 'SUBJECTS_LOAD_FAILURE':
+    case ActionTypes.SUBJECTS_LOAD_FAILURE:
       return { ...state, loading: false, error: action.error };
     default:
       return state;

--- a/src/Stores/SubjectsPromises/__tests__/selectors.test.js
+++ b/src/Stores/SubjectsPromises/__tests__/selectors.test.js
@@ -22,7 +22,7 @@ describe('SubjectsPromises Selector', () => {
       ...initialState,
       subjectsPromises: {
         ...initialState.subjectsPromises,
-        subjectsPromises,
+        data: subjectsPromises,
       },
     };
 

--- a/src/Stores/SubjectsPromises/__tests__/selectors.test.js
+++ b/src/Stores/SubjectsPromises/__tests__/selectors.test.js
@@ -26,6 +26,8 @@ describe('SubjectsPromises Selector', () => {
       },
     };
 
+    deepFreeze(loadedState);
+
     expect(subjectsPromisesSelector(loadedState)).toEqual(subjectsPromises);
   });
 });

--- a/src/Stores/SubjectsPromises/__tests__/selectors.test.js
+++ b/src/Stores/SubjectsPromises/__tests__/selectors.test.js
@@ -1,0 +1,31 @@
+/* @flow */
+import deepFreeze from 'deep-freeze';
+import { subjectsPromisesSelector } from '../selectors';
+import { initialState } from '../../../utils/testFixtures';
+
+describe('SubjectsPromises Selector', () => {
+  it('loads initial state', () => {
+    expect(subjectsPromisesSelector(initialState)).toEqual(null);
+  });
+
+  it('Returns subjectPromises', () => {
+    const subjectsPromises = [
+      {
+        id: 1,
+        promise: 4,
+        subject: 3,
+        created: '2017-11-12T12:24:14.060672Z',
+        modified: '2017-11-12T12:24:14.060699Z',
+      },
+    ];
+    const loadedState = {
+      ...initialState,
+      subjectsPromises: {
+        ...initialState.subjectsPromises,
+        subjectsPromises,
+      },
+    };
+
+    expect(subjectsPromisesSelector(loadedState)).toEqual(subjectsPromises);
+  });
+});

--- a/src/Stores/SubjectsPromises/actions.js
+++ b/src/Stores/SubjectsPromises/actions.js
@@ -1,17 +1,24 @@
 /* @flow */
+
 import type { Dispatch, SubjectPromise } from '../../types';
 import { getSubjectsPromises as apiGetSubjectsPromises } from '../../utils/api';
 
-const getSubjectsPromises = () => ({ type: 'SUBJECTS_PROMISES_LOAD' });
+export const ActionTypes = {
+  SUBJECTS_PROMISES_LOAD: 'SUBJECTS_PROMISES_LOAD',
+  SUBJECTS_PROMISES_LOAD_SUCCESS: 'SUBJECTS_PROMISES_LOAD_SUCCESS',
+  SUBJECTS_PROMISES_LOAD_FAILURE: 'SUBJECTS_PROMISES_LOAD_FAILURE',
+};
+
+const getSubjectsPromises = () => ({ type: ActionTypes.SUBJECTS_PROMISES_LOAD });
 
 const getSubjectsPromisesSuccess = (data: Array<SubjectPromise>) => ({
   data,
-  type: 'SUBJECTS_PROMISES_LOAD_SUCCESS',
+  type: ActionTypes.SUBJECTS_PROMISES_LOAD_SUCCESS,
 });
 
 const getSubjectsPromisesFailure = (error: *) => ({
   error,
-  type: 'SUBJECTS_PROMISES_LOAD_FAILURE',
+  type: ActionTypes.SUBJECTS_PROMISES_LOAD_FAILURE,
 });
 
 export const fetchSubjectsPromises = () => (dispatch: Dispatch) => {

--- a/src/Stores/SubjectsPromises/actions.js
+++ b/src/Stores/SubjectsPromises/actions.js
@@ -1,0 +1,31 @@
+/* @flow */
+import type { Dispatch, SubjectPromise } from '../../types';
+import { getSubjectsPromises as apiGetSubjectsPromises } from '../../utils/api';
+
+const getSubjectsPromises = () => ({ type: 'SUBJECTS_PROMISES_LOAD' });
+
+const getSubjectsPromisesSuccess = (subjectsPromises: Array<SubjectPromise>) => ({
+  subjectsPromises,
+  type: 'SUBJECTS_PROMISES_LOAD_SUCCESS',
+});
+
+const getSubjectsPromisesFailure = (error: *) => ({
+  error,
+  type: 'SUBJECTS_PROMISES_LOAD_FAILURE',
+});
+
+export const fetchSubjectsPromises = () => (dispatch: Dispatch) => {
+  dispatch(getSubjectsPromises());
+
+  return apiGetSubjectsPromises().then(
+    resp => resp.data && dispatch(getSubjectsPromisesSuccess(resp.data)),
+    error => dispatch(getSubjectsPromisesFailure(error.message))
+  );
+};
+
+export default {
+  getSubjectsPromises,
+  getSubjectsPromisesSuccess,
+  getSubjectsPromisesFailure,
+  fetchSubjectsPromises,
+};

--- a/src/Stores/SubjectsPromises/actions.js
+++ b/src/Stores/SubjectsPromises/actions.js
@@ -4,8 +4,8 @@ import { getSubjectsPromises as apiGetSubjectsPromises } from '../../utils/api';
 
 const getSubjectsPromises = () => ({ type: 'SUBJECTS_PROMISES_LOAD' });
 
-const getSubjectsPromisesSuccess = (subjectsPromises: Array<SubjectPromise>) => ({
-  subjectsPromises,
+const getSubjectsPromisesSuccess = (data: Array<SubjectPromise>) => ({
+  data,
   type: 'SUBJECTS_PROMISES_LOAD_SUCCESS',
 });
 

--- a/src/Stores/SubjectsPromises/reducer.js
+++ b/src/Stores/SubjectsPromises/reducer.js
@@ -2,13 +2,13 @@
 import type { SubjectPromise, Action } from '../../types';
 
 export type State = {
-  +subjectsPromises: ?Array<SubjectPromise>,
+  +data: ?Array<SubjectPromise>,
   +loading: boolean,
   +error: *,
 };
 
 const initialState = {
-  subjectsPromises: null,
+  data: null,
   loading: false,
   error: null,
 };
@@ -16,14 +16,14 @@ const initialState = {
 const subjectsPromisesReducer = (state: State = initialState, action: Action): State => {
   switch (action.type) {
     case 'SUBJECTS_PROMISES_LOAD':
-      return { ...state, loading: true, subjectsPromises: null, error: null };
+      return { ...state, loading: true, data: null, error: null };
     case 'SUBJECTS_PROMISES_LOAD_SUCCESS':
-      return { ...state, loading: false, subjectsPromises: action.subjects };
+      return { ...state, loading: false, data: action.subjects };
     case 'SUBJECTS_PROMISES_LOAD_FAILURE':
       return { ...state, loading: false, error: action.error };
     case 'SUBJECT_PROMISE_LINK_SUCCESS': {
-      const nullGuard = state.subjectsPromises || [];
-      return { ...state, subjectsPromises: [...nullGuard, action.payload] };
+      const nullGuard = state.data || [];
+      return { ...state, data: [...nullGuard, action.payload] };
     }
     default:
       return state;

--- a/src/Stores/SubjectsPromises/reducer.js
+++ b/src/Stores/SubjectsPromises/reducer.js
@@ -1,0 +1,33 @@
+/* @flow */
+import type { SubjectPromise, Action } from '../../types';
+
+export type State = {
+  +subjectsPromises: ?Array<SubjectPromise>,
+  +loading: boolean,
+  +error: *,
+};
+
+const initialState = {
+  subjectsPromises: null,
+  loading: false,
+  error: null,
+};
+
+const subjectsPromisesReducer = (state: State = initialState, action: Action): State => {
+  switch (action.type) {
+    case 'SUBJECTS_PROMISES_LOAD':
+      return { ...state, loading: true, subjectsPromises: null, error: null };
+    case 'SUBJECTS_PROMISES_LOAD_SUCCESS':
+      return { ...state, loading: false, subjectsPromises: action.subjects };
+    case 'SUBJECTS_PROMISES_LOAD_FAILURE':
+      return { ...state, loading: false, error: action.error };
+    case 'SUBJECT_PROMISE_LINK_SUCCESS': {
+      const nullGuard = state.subjectsPromises || [];
+      return { ...state, subjectsPromises: [...nullGuard, action.payload] };
+    }
+    default:
+      return state;
+  }
+};
+
+export default subjectsPromisesReducer;

--- a/src/Stores/SubjectsPromises/reducer.js
+++ b/src/Stores/SubjectsPromises/reducer.js
@@ -1,5 +1,7 @@
 /* @flow */
 import type { SubjectPromise, Action } from '../../types';
+import { ActionTypes } from './actions';
+import { ActionTypes as SubjectActionTypes } from '../Subjects/actions';
 
 export type State = {
   +data: ?Array<SubjectPromise>,
@@ -15,13 +17,13 @@ const initialState = {
 
 const subjectsPromisesReducer = (state: State = initialState, action: Action): State => {
   switch (action.type) {
-    case 'SUBJECTS_PROMISES_LOAD':
+    case ActionTypes.SUBJECTS_PROMISES_LOAD:
       return { ...state, loading: true, data: null, error: null };
-    case 'SUBJECTS_PROMISES_LOAD_SUCCESS':
+    case ActionTypes.SUBJECTS_PROMISES_LOAD_SUCCESS:
       return { ...state, loading: false, data: action.subjects };
-    case 'SUBJECTS_PROMISES_LOAD_FAILURE':
+    case ActionTypes.SUBJECTS_PROMISES_LOAD_FAILURE:
       return { ...state, loading: false, error: action.error };
-    case 'SUBJECT_PROMISE_LINK_SUCCESS': {
+    case SubjectActionTypes.SUBJECT_PROMISE_LINK_SUCCESS: {
       const nullGuard = state.data || [];
       return { ...state, data: [...nullGuard, action.payload] };
     }

--- a/src/Stores/SubjectsPromises/selectors.js
+++ b/src/Stores/SubjectsPromises/selectors.js
@@ -2,7 +2,7 @@
 import type { State } from '../../types';
 
 export const subjectsPromisesSelector = (state: State) => {
-  const subjectPromises = state.subjectsPromises.subjectsPromises;
+  const subjectPromises = state.subjectsPromises.data;
 
   if (!subjectPromises) return null;
 

--- a/src/Stores/SubjectsPromises/selectors.js
+++ b/src/Stores/SubjectsPromises/selectors.js
@@ -1,0 +1,10 @@
+/* @flow */
+import type { State } from '../../types';
+
+export const subjectsPromisesSelector = (state: State) => {
+  const subjectPromises = state.subjectsPromises.subjectsPromises;
+
+  if (!subjectPromises) return null;
+
+  return subjectPromises;
+};

--- a/src/Stores/SubjectsPromises/selectors.js
+++ b/src/Stores/SubjectsPromises/selectors.js
@@ -1,10 +1,5 @@
 /* @flow */
 import type { State } from '../../types';
 
-export const subjectsPromisesSelector = (state: State) => {
-  const subjectPromises = state.subjectsPromises.data;
-
-  if (!subjectPromises) return null;
-
-  return subjectPromises;
-};
+export const subjectsPromisesSelector = (state: State) =>
+  state.subjectsPromises.data ? state.subjectsPromises.data : null;

--- a/src/Stores/rootReducer.js
+++ b/src/Stores/rootReducer.js
@@ -3,12 +3,14 @@ import { combineReducers } from 'redux';
 import PoliticiansReducer from './Politicians/reducer';
 import PromisesReducer from './Promises/reducer';
 import SubjectsReducer from './Subjects/reducer';
+import SubjectsPromisesReducer from './SubjectsPromises/reducer';
 import FeedbackReducer from './Feedback/reducer';
 
 const reducer = combineReducers({
   politicians: PoliticiansReducer,
   promises: PromisesReducer,
   subjects: SubjectsReducer,
+  subjectsPromises: SubjectsPromisesReducer,
   feedback: FeedbackReducer,
 });
 

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ export type PoliticianId = number;
 export type DistrictId = number;
 export type SubjectId = number;
 export type ParliamentSessionId = number;
+export type SubjectPromiseId = number;
 
 export type CaseIdParam = {
   caseId: number,
@@ -98,6 +99,14 @@ export type Subject = {
   parent: ?string,
 };
 
+export type SubjectPromise = {
+  id: SubjectPromiseId,
+  subject: SubjectId,
+  promise: PromiseId,
+  created: string,
+  modified: string,
+};
+
 // Redux
 
 export type Dispatch = (action: Action | ThunkAction | PromiseAction) => *;
@@ -120,6 +129,11 @@ export type State = {
     error: ?string,
     loading: boolean,
     subjects: ?Array<Subject>,
+  },
+  subjectsPromises: {
+    error: ?string,
+    loading: boolean,
+    subjectsPromises: ?Array<SubjectPromise>,
   },
   feedback: {
     message: ?string,

--- a/src/types.js
+++ b/src/types.js
@@ -133,7 +133,7 @@ export type State = {
   subjectsPromises: {
     error: ?string,
     loading: boolean,
-    subjectsPromises: ?Array<SubjectPromise>,
+    data: ?Array<SubjectPromise>,
   },
   feedback: {
     message: ?string,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -207,6 +207,25 @@ export const linkSubjectPromise = (promiseId: PromiseId, subjectId: SubjectId) =
     .catch(error => ({ error }));
 };
 
+export const getSubjectsPromises = () => {
+  const token = getToken();
+  if (!token) {
+    throw new Error('Unauthorized action');
+  }
+
+  return fetch(`${serverBaseUrl}/v1/promises/subjects/`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`,
+    },
+  })
+    .then(checkStatus)
+    .then(parseJSON)
+    .then(mapData)
+    .catch(error => ({ error }));
+};
+
 export const createSubject = (subject: string): DataResponse<Subject> => {
   const token = getToken();
   if (!token) {

--- a/src/utils/testFixtures.js
+++ b/src/utils/testFixtures.js
@@ -230,6 +230,11 @@ export const initialState: State = {
     error: null,
     loading: false,
   },
+  subjectsPromises: {
+    subjectsPromises: null,
+    error: null,
+    loading: false,
+  },
   feedback: {
     message: null,
   },

--- a/src/utils/testFixtures.js
+++ b/src/utils/testFixtures.js
@@ -231,7 +231,7 @@ export const initialState: State = {
     loading: false,
   },
   subjectsPromises: {
-    subjectsPromises: null,
+    data: null,
     error: null,
     loading: false,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,6 +2304,10 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
+deep-freeze@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
## Status
**Ready**

## Description
Initial work required to map Subjects to promises on the frontend

## Example | Screenshots
**Note that the component Prop `promise` contains a `subject` property
<img width="1680" alt="screen shot 2017-11-14 at 19 26 56" src="https://user-images.githubusercontent.com/22854722/32797483-3534f030-c972-11e7-903f-a17ff06fed84.png">

## Todos
- [ ] Make tests
- [x] Clean up commit history
