### PR TITLE
List of cases facelift and now leads to case detail page

### DIFF
--- a/src/Components/Cases/Case/index.js
+++ b/src/Components/Cases/Case/index.js
@@ -22,15 +22,14 @@ export class CaseContainer extends React.Component {
         display: 'flex',
         flexDirection: 'column',
       },
-      item: {
-        flex: '0 0 30%',
+      case: {
         margin: 10,
       },
     };
     return (
       <div style={styles.container}>
         {this.state.cases.map(parliament_case =>
-          <div key={parliament_case.id} style={styles.item}>
+          <div key={parliament_case.id} style={styles.case}>
             <CaseCard parliament_case={parliament_case} />
           </div>
         )}

--- a/src/Components/Cases/Case/index.js
+++ b/src/Components/Cases/Case/index.js
@@ -17,10 +17,22 @@ export class CaseContainer extends React.Component {
     });
   }
   render() {
+    const styles = {
+      container: {
+        display: 'flex',
+        flexDirection: 'column',
+      },
+      item: {
+        flex: '0 0 30%',
+        margin: 10,
+      },
+    };
     return (
-      <div>
+      <div style={styles.container}>
         {this.state.cases.map(parliament_case =>
-          <CaseCard key={parliament_case.id} parliament_case={parliament_case} />
+          <div key={parliament_case.id} style={styles.item}>
+            <CaseCard parliament_case={parliament_case} />
+          </div>
         )}
       </div>
     );

--- a/src/Components/Cases/CaseCard/index.js
+++ b/src/Components/Cases/CaseCard/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Paper from 'material-ui/Paper';
 
 import type { Case } from '../types';
@@ -15,19 +16,24 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'space-between',
   },
+  link: {
+    textDecoration: 'none',
+  },
 };
 
 const CaseCard = (props: Props) => {
   const { parliament_case } = props;
   return (
-    <Paper zDepth={1} rounded={false} style={styles.container}>
-      <div>
-        <h2>{parliament_case.name}</h2>
-      </div>
-      <div>
-        <span>{parliament_case.case_type}</span>
-      </div>
-    </Paper>
+    <Link to={`/cases/${parliament_case.id}`} style={styles.link}>
+      <Paper zDepth={1} rounded={false} style={styles.container}>
+        <div>
+          <h2>{parliament_case.name}</h2>
+        </div>
+        <div>
+          <span>{parliament_case.case_type}</span>
+        </div>
+      </Paper>
+    </Link>
   );
 };
 

--- a/src/Components/Cases/CaseCard/index.js
+++ b/src/Components/Cases/CaseCard/index.js
@@ -4,21 +4,10 @@ import { Link } from 'react-router-dom';
 import Paper from 'material-ui/Paper';
 
 import type { Case } from '../types';
+import styles from './styles';
 
 export type Props = {
   parliament_case: Case,
-};
-
-const styles = {
-  container: {
-    padding: 10,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  link: {
-    textDecoration: 'none',
-  },
 };
 
 const CaseCard = (props: Props) => {

--- a/src/Components/Cases/CaseCard/index.js
+++ b/src/Components/Cases/CaseCard/index.js
@@ -1,11 +1,8 @@
 /* @flow */
 import React from 'react';
-import { Card, CardHeader, CardText } from 'material-ui/Card';
 import Paper from 'material-ui/Paper';
 
 import type { Case } from '../types';
-
-const moment = require('moment');
 
 export type Props = {
   parliament_case: Case,
@@ -13,57 +10,24 @@ export type Props = {
 
 const styles = {
   container: {
-    width: '100%',
-    overflow: 'auto',
-  },
-  field: {
-    width: '27%',
-    margin: '3%',
-    float: 'left',
+    padding: 10,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
 };
 
 const CaseCard = (props: Props) => {
   const { parliament_case } = props;
   return (
-    <Card key={parliament_case.id}>
-      <CardHeader
-        title={parliament_case.name}
-        subtitle={parliament_case.parliament_session}
-        actAsExpander={true}
-        showExpandableButton={true}
-      />
-      <CardText expandable={true}>
-        <Paper zDepth={1} rounded={false}>
-          <div style={styles.container}>
-            <div style={styles.field}>
-              <span>Parliament: {parliament_case.parliament_session}</span>
-            </div>
-            <div style={styles.field}>
-              <span>Parliament session: {parliament_case.parliament_session}</span>
-            </div>
-            <div style={styles.field}>
-              <span>Type: {parliament_case.case_type}</span>
-            </div>
-          </div>
-          <div style={styles.container}>
-            <div style={styles.field}>
-              <span>Status: {parliament_case.status}</span>
-            </div>
-            <div style={styles.field}>
-              <span>
-                Created on {moment(parliament_case.created).format('MMM Mo YYYY')}
-              </span>
-            </div>
-            <div style={styles.field}>
-              <span>
-                Last Modified on {moment(parliament_case.modified).format('MMM Mo YYYY')}
-              </span>
-            </div>
-          </div>
-        </Paper>
-      </CardText>
-    </Card>
+    <Paper zDepth={1} rounded={false} style={styles.container}>
+      <div>
+        <h2>{parliament_case.name}</h2>
+      </div>
+      <div>
+        <span>{parliament_case.case_type}</span>
+      </div>
+    </Paper>
   );
 };
 

--- a/src/Components/Cases/CaseCard/styles.js
+++ b/src/Components/Cases/CaseCard/styles.js
@@ -1,0 +1,11 @@
+export default {
+  container: {
+    padding: 10,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  link: {
+    textDecoration: 'none',
+  },
+};


### PR DESCRIPTION
## Status
**Ready**

## Description
Cases page now uses flex and has a bit smoother interface. It now also links to the case detail page when clicked. Next step would be to flesh out the case details page.

## Example | Screenshots
![selection_001](https://user-images.githubusercontent.com/6696198/33627018-8a00d116-d9fc-11e7-92cb-cc355a6ce3b1.png)

![selection_001](https://user-images.githubusercontent.com/6696198/36740185-00542300-1be2-11e8-908d-3275203acf67.png)
