### PR TITLE
Show subjects and support unlinking them from Promises

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "react-app"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "formsy-material-ui": "^0.6.0",
     "formsy-react": "^0.19.2",
+    "lodash.filter": "^4.6.0",
     "moment": "^2.18.1",
     "react": "^15.5.3",
     "react-dom": "^15.5.3",

--- a/src/Components/Promises/PromiseContainer/index.js
+++ b/src/Components/Promises/PromiseContainer/index.js
@@ -3,22 +3,39 @@ import React from 'react';
 import { connect } from 'react-redux';
 import type { Connector } from 'react-redux';
 import { fetchPromises } from '../../../Stores/Promises/actions';
-import { linkSubjectToPromisesThunk } from '../../../Stores/Subjects/actions';
+import {
+  fetchSubjects,
+  linkSubjectToPromisesThunk,
+} from '../../../Stores/Subjects/actions';
+import {
+  fetchSubjectsPromises,
+  unlinkSubjectPromiseThunk,
+} from '../../../Stores/SubjectsPromises/actions';
 import {
   promiseSubjectsSelector,
   promisesLoaded,
 } from '../../../Stores/Promises/selectors';
-import type { Dispatch, State, PromiseType, PromiseId, SubjectId } from '../../../types';
+import type {
+  Dispatch,
+  State,
+  DecoratedPromise,
+  PromiseId,
+  SubjectId,
+  SubjectPromiseId,
+} from '../../../types';
 import PromiseTable from '../PromiseTable';
 
 type OwnProps = {};
 
 type ReduxProps = {
-  promises: ?Array<PromiseType>,
+  promises: ?Array<DecoratedPromise>,
   hasLoadedPromises: boolean,
   error: ?string,
-  fetchPromises: () => void,
+  getPromises: () => void,
+  getSubjects: () => void,
+  getSubjectsPromises: () => void,
   linkSubjectToPromises: (promiseIds: Array<PromiseId>, subjectId: SubjectId) => void,
+  unlinkSubjectPromise: (subjectPromiseId: SubjectPromiseId) => void,
 };
 
 type Props = OwnProps & ReduxProps;
@@ -27,18 +44,30 @@ export class PromiseContainer extends React.Component {
   props: Props;
 
   componentDidMount() {
-    const { hasLoadedPromises } = this.props;
+    const {
+      hasLoadedPromises,
+      getPromises,
+      getSubjects,
+      getSubjectsPromises,
+    } = this.props;
     if (!hasLoadedPromises) {
-      this.props.fetchPromises();
+      getPromises();
     }
+
+    getSubjects();
+    getSubjectsPromises();
   }
 
   render() {
-    const { promises, linkSubjectToPromises } = this.props;
+    const { promises, linkSubjectToPromises, unlinkSubjectPromise } = this.props;
     if (!promises) return null;
 
     return (
-      <PromiseTable promises={promises} linkSubjectToPromises={linkSubjectToPromises} />
+      <PromiseTable
+        promises={promises}
+        linkSubjectToPromises={linkSubjectToPromises}
+        unlinkSubjectPromise={unlinkSubjectPromise}
+      />
     );
   }
 }
@@ -53,11 +82,19 @@ const mapStateToProps = (state: State) => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    fetchPromises: () => {
+    getPromises: () => {
       dispatch(fetchPromises());
+    },
+    getSubjects: () => {
+      dispatch(fetchSubjects());
+    },
+    getSubjectsPromises: () => {
+      dispatch(fetchSubjectsPromises());
     },
     linkSubjectToPromises: (promiseIds: Array<PromiseId>, subjectId: SubjectId) =>
       dispatch(linkSubjectToPromisesThunk(promiseIds, subjectId)),
+    unlinkSubjectPromise: (subjectPromiseId: SubjectPromiseId) =>
+      dispatch(unlinkSubjectPromiseThunk(subjectPromiseId)),
   };
 };
 

--- a/src/Components/Promises/PromiseTable/index.js
+++ b/src/Components/Promises/PromiseTable/index.js
@@ -10,7 +10,8 @@ import {
 } from 'material-ui/Table';
 import InCompleteIcon from 'material-ui/svg-icons/navigation/close';
 import CompleteIcon from 'material-ui/svg-icons/navigation/check';
-import { red500, green500 } from 'material-ui/styles/colors';
+import Chip from 'material-ui/Chip';
+import { red500, green500, blue300 } from 'material-ui/styles/colors';
 import PromiseTableAdminPanel from '../PromiseTableAdminPanel';
 import type {
   DecoratedPromise,
@@ -18,10 +19,12 @@ import type {
   SubjectId,
   DecoratedSubject,
 } from '../../../types';
+import { deleteSubjectPromise } from '../../../utils/api';
 
 export type Props = {
   promises: Array<DecoratedPromise>,
   linkSubjectToPromises: (promiseIds: Array<PromiseId>, subjectId: SubjectId) => void,
+  unlinkSubjectPromise: (subjectPromiseId: number) => void,
 };
 
 const getIcon = fulfilled =>
@@ -35,13 +38,23 @@ export class PromiseTable extends React.Component {
   };
 
   linkSubjectsCallback = (subjectId: SubjectId) => {
-    const { linkSubjectToPromises } = this.props;
     const { selectedPromises } = this.state;
+    const { linkSubjectToPromises } = this.props;
+    if (selectedPromises.length === 0) {
+      return;
+    }
 
+    // $FlowFixMe: promise.id is not undefined. Shhh flow
     const promiseIds = selectedPromises.map(promise => promise.id);
+    if (!promiseIds) {
+      return;
+    }
     linkSubjectToPromises(promiseIds, subjectId);
   };
 
+  onUnLinkSubject = (subjectId: SubjectId) => {
+    deleteSubjectPromise(subjectId);
+  };
   onRowSelect = (selection: 'all' | 'none' | Array<number>) => {
     const refine = selection;
     if (refine === 'all') {
@@ -58,6 +71,20 @@ export class PromiseTable extends React.Component {
     }
   };
 
+  renderSubjects = (subjects?: Array<DecoratedSubject>) => {
+    if (!subjects) return null;
+    const { unlinkSubjectPromise } = this.props;
+    return subjects.map(subject =>
+      <Chip
+        key={subject.id}
+        backgroundColor={blue300}
+        onRequestDelete={() => unlinkSubjectPromise(subject.subjectPromiseId)}
+      >
+        {subject.name}
+      </Chip>
+    );
+  };
+
   render() {
     const { promises } = this.props;
     if (!promises) {
@@ -70,6 +97,7 @@ export class PromiseTable extends React.Component {
         <TableRowColumn>{promise.politician}</TableRowColumn>
         <TableRowColumn>{promise.small_description}</TableRowColumn>
         <TableRowColumn>{getIcon(promise.fulfilled)}</TableRowColumn>
+        <TableRowColumn>{this.renderSubjects(promise.subjects)}</TableRowColumn>
       </TableRow>
     );
 
@@ -91,6 +119,7 @@ export class PromiseTable extends React.Component {
             <TableHeaderColumn>Politician id</TableHeaderColumn>
             <TableHeaderColumn>Short description</TableHeaderColumn>
             <TableHeaderColumn>Fulfilled</TableHeaderColumn>
+            <TableHeaderColumn>Subjects</TableHeaderColumn>
           </TableRow>
         </TableHeader>
         <TableBody deselectOnClickaway={false}>{promiseRows}</TableBody>

--- a/src/Components/Promises/PromiseTable/index.js
+++ b/src/Components/Promises/PromiseTable/index.js
@@ -12,10 +12,15 @@ import InCompleteIcon from 'material-ui/svg-icons/navigation/close';
 import CompleteIcon from 'material-ui/svg-icons/navigation/check';
 import { red500, green500 } from 'material-ui/styles/colors';
 import PromiseTableAdminPanel from '../PromiseTableAdminPanel';
-import type { PromiseType, PromiseId, SubjectId } from '../../../types';
+import type {
+  DecoratedPromise,
+  PromiseId,
+  SubjectId,
+  DecoratedSubject,
+} from '../../../types';
 
 export type Props = {
-  promises: Array<PromiseType>,
+  promises: Array<DecoratedPromise>,
   linkSubjectToPromises: (promiseIds: Array<PromiseId>, subjectId: SubjectId) => void,
 };
 

--- a/src/Components/Promises/PromiseTable/stories/PromiseTable.stories.js
+++ b/src/Components/Promises/PromiseTable/stories/PromiseTable.stories.js
@@ -5,11 +5,28 @@ import { muiTheme } from 'storybook-addon-material-ui';
 import PromiseTable from '../index';
 import { promises } from '../../../../utils/testFixtures';
 
+const decoratedSubject = {
+  id: 5,
+  subjectPromiseId: 33,
+  name: 'Zubject',
+  created: '2017-06-10T14:06:32.542308Z',
+  modified: '2017-06-10T14:06:32.542331Z',
+  description: null,
+  parliament_session: null,
+  number: null,
+  parent: null,
+};
+
+const decoratedPromises = promises.map(promise => ({
+  ...promise,
+  subjects: [decoratedSubject],
+}));
+
 storiesOf('Promise Table', module)
   .addDecorator(muiTheme())
   .add('Default', () =>
     <PromiseTable
-      promises={promises}
+      promises={decoratedPromises}
       linkSubjectToPromises={action('link subject to promises')}
     />
   );

--- a/src/Components/Promises/PromiseTable/stories/PromiseTable.stories.js
+++ b/src/Components/Promises/PromiseTable/stories/PromiseTable.stories.js
@@ -28,5 +28,6 @@ storiesOf('Promise Table', module)
     <PromiseTable
       promises={decoratedPromises}
       linkSubjectToPromises={action('link subject to promises')}
+      unlinkSubjectPromise={action('unlink subject to promise')}
     />
   );

--- a/src/Stores/Promises/__tests__/selectors.test.js
+++ b/src/Stores/Promises/__tests__/selectors.test.js
@@ -68,6 +68,17 @@ describe('Promises selector', () => {
       },
     ];
 
+    const decoratedSubjects = [
+      {
+        ...testSubjects[0],
+        subjectPromiseId: 1,
+      },
+      {
+        ...testSubjects[1],
+        subjectPromiseId: 2,
+      },
+    ];
+
     const combinedPromise = {
       name: 'Some title',
       small_description: 'Another title',
@@ -82,7 +93,7 @@ describe('Promises selector', () => {
       politician: politician,
       party: 1,
       fulfilled: true,
-      subjects: testSubjects,
+      subjects: decoratedSubjects,
     };
 
     const subjectsPromises = [

--- a/src/Stores/Promises/selectors.js
+++ b/src/Stores/Promises/selectors.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { State, PromiseType } from '../../types';
+import type { State, PromiseType, DecoratedPromise } from '../../types';
 import { subjectsSelector } from '../Subjects/selectors';
 import { subjectsPromisesSelector } from '../SubjectsPromises/selectors';
 import { createSelector } from 'reselect';
@@ -10,22 +10,34 @@ export const promisesSelector = (state: State): ?Array<PromiseType> =>
 export const promiseSubjectsSelector: (
   state: State
 ) => ?Array<
-  PromiseType
+  DecoratedPromise
 > = createSelector(
   promisesSelector,
   subjectsSelector,
   subjectsPromisesSelector,
   (promises, subjects, subjectsPromises) => {
-    if (!promises) {
+    // Need to pull this to a const so that Flow understands nothing has changed
+    const _subjects = subjects;
+    if (!promises || !_subjects) {
       return null;
     }
     return promises.map(promise => {
       const links = subjectsPromises
         ? subjectsPromises.filter(sP => sP.promise === promise.id)
         : [];
-      const subs = links.map(
-        link => (subjects ? subjects.find(s => link.subject === s.id) : [])
-      );
+      const subs = links.map(link => {
+        const subject = _subjects.find(s => link.subject === s.id);
+        if (!subject) {
+          throw new Error(
+            'Promises selector: Found subjectPromise link without subject',
+            link
+          );
+        }
+        return {
+          ...subject,
+          subjectPromiseId: link.id,
+        };
+      });
       return { ...promise, subjects: subs };
     });
   }

--- a/src/Stores/SubjectsPromises/actions.js
+++ b/src/Stores/SubjectsPromises/actions.js
@@ -1,12 +1,18 @@
 /* @flow */
 
-import type { Dispatch, SubjectPromise } from '../../types';
-import { getSubjectsPromises as apiGetSubjectsPromises } from '../../utils/api';
+import type { Dispatch, SubjectPromise, SubjectPromiseId } from '../../types';
+import {
+  getSubjectsPromises as apiGetSubjectsPromises,
+  deleteSubjectPromise as apiDeleteSubjectPromise,
+} from '../../utils/api';
 
 export const ActionTypes = {
   SUBJECTS_PROMISES_LOAD: 'SUBJECTS_PROMISES_LOAD',
   SUBJECTS_PROMISES_LOAD_SUCCESS: 'SUBJECTS_PROMISES_LOAD_SUCCESS',
   SUBJECTS_PROMISES_LOAD_FAILURE: 'SUBJECTS_PROMISES_LOAD_FAILURE',
+  SUBJECT_PROMISE_UNLINK: 'SUBJECT_PROMISE_UNLINK',
+  SUBJECT_PROMISE_UNLINK_SUCCESS: 'SUBJECT_PROMISE_UNLINK_SUCCESS',
+  SUBJECT_PROMISE_UNLINK_FAILURE: 'SUBJECT_PROMISE_UNLINK_FAILURE',
 };
 
 const getSubjectsPromises = () => ({ type: ActionTypes.SUBJECTS_PROMISES_LOAD });
@@ -30,9 +36,33 @@ export const fetchSubjectsPromises = () => (dispatch: Dispatch) => {
   );
 };
 
+const unlinkSubjectPromise = () => ({ type: ActionTypes.SUBJECT_PROMISE_UNLINK });
+
+const unlinkSubjectPromiseSuccess = (id: SubjectPromiseId) => ({
+  type: ActionTypes.SUBJECT_PROMISE_UNLINK_SUCCESS,
+  id,
+});
+
+const unlinkSubjectPromiseFailure = error => ({
+  type: ActionTypes.SUBJECT_PROMISE_UNLINK_FAILURE,
+  error,
+});
+
+export const unlinkSubjectPromiseThunk = (subjectPromiseId: SubjectPromiseId) => (
+  dispatch: Dispatch
+) => {
+  dispatch(unlinkSubjectPromise(subjectPromiseId));
+
+  return apiDeleteSubjectPromise(subjectPromiseId).then(
+    () => dispatch(unlinkSubjectPromiseSuccess(subjectPromiseId)),
+    error => dispatch(unlinkSubjectPromiseFailure(error.message))
+  );
+};
+
 export default {
   getSubjectsPromises,
   getSubjectsPromisesSuccess,
   getSubjectsPromisesFailure,
   fetchSubjectsPromises,
+  unlinkSubjectPromiseThunk,
 };

--- a/src/Stores/SubjectsPromises/reducer.js
+++ b/src/Stores/SubjectsPromises/reducer.js
@@ -20,7 +20,7 @@ const subjectsPromisesReducer = (state: State = initialState, action: Action): S
     case ActionTypes.SUBJECTS_PROMISES_LOAD:
       return { ...state, loading: true, data: null, error: null };
     case ActionTypes.SUBJECTS_PROMISES_LOAD_SUCCESS:
-      return { ...state, loading: false, data: action.subjects };
+      return { ...state, loading: false, data: action.data };
     case ActionTypes.SUBJECTS_PROMISES_LOAD_FAILURE:
       return { ...state, loading: false, error: action.error };
     case SubjectActionTypes.SUBJECT_PROMISE_LINK_SUCCESS: {

--- a/src/Stores/SubjectsPromises/reducer.js
+++ b/src/Stores/SubjectsPromises/reducer.js
@@ -23,6 +23,13 @@ const subjectsPromisesReducer = (state: State = initialState, action: Action): S
       return { ...state, loading: false, data: action.data };
     case ActionTypes.SUBJECTS_PROMISES_LOAD_FAILURE:
       return { ...state, loading: false, error: action.error };
+    case ActionTypes.SUBJECT_PROMISE_UNLINK_SUCCESS: {
+      const filteredSPs = state.data && state.data.filter(sp => sp.id !== action.id);
+      return { ...state, loading: false, data: filteredSPs };
+    }
+    case ActionTypes.SUBJECT_PROMISE_UNLINK_FAILURE:
+      return { ...state, loading: false, error: action.error };
+
     case SubjectActionTypes.SUBJECT_PROMISE_LINK_SUCCESS: {
       const nullGuard = state.data || [];
       return { ...state, data: [...nullGuard, action.payload] };

--- a/src/types.js
+++ b/src/types.js
@@ -44,6 +44,22 @@ export type PromiseType = {
   fulfilled: boolean,
 };
 
+export type DecoratedPromise = {
+  ...PromiseType,
+  subjects: Array<DecoratedSubject>,
+};
+
+export type DecoratedSubject = {
+  ...Subject,
+  subjectPromiseId: SubjectPromiseId,
+};
+
+export type PartyType = {
+  id: PartyId,
+  name: string,
+  website: string,
+};
+
 export type PoliticianType = {
   id: PoliticianId,
   name: string,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -44,6 +44,9 @@ export type PromiseFormType = {
 };
 
 export type PartyId = number;
+const STATUS_CODES = {
+  NO_CONTENT: 204,
+};
 
 export const checkStatus = (response: Response) => {
   /* eslint-disable no-magic-numbers */
@@ -56,12 +59,11 @@ export const checkStatus = (response: Response) => {
   throw error;
 };
 
-export const parseJSON = (response: Response) => {
-  return response.json();
-};
+export const parseJSON = (response: Response) =>
+  response.status === STATUS_CODES.NO_CONTENT ? null : response.json();
 
-export const mapData = (json: JSON) => {
-  const data = json.results ? json.results : json;
+export const mapData = (json: ?JSON) => {
+  const data = json && json.results ? json.results : json;
   return { data };
 };
 
@@ -199,6 +201,25 @@ export const getSubjectsPromises = () => {
 
   return fetch(`${serverBaseUrl}/v1/promises/subjects/`, {
     method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`,
+    },
+  })
+    .then(checkStatus)
+    .then(parseJSON)
+    .then(mapData)
+    .catch(error => ({ error }));
+};
+
+export const deleteSubjectPromise = (subjectId: SubjectId) => {
+  const token = getToken();
+  if (!token) {
+    throw new Error('Unauthorized action');
+  }
+
+  return fetch(`${serverBaseUrl}/v1/promises/subjects/${subjectId}`, {
+    method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Token ${token}`,

--- a/src/utils/testFixtures.js
+++ b/src/utils/testFixtures.js
@@ -29,7 +29,7 @@ export const districts: Array<DetailedDistrictType> = [
   },
 ];
 
-export const promises: Array<PromiseType> = [
+export const promises = [
   {
     name: 'Some title',
     small_description: 'Another title',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4722,7 +4722,7 @@ lodash.defaults@^4.0.1, lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.filter@^4.4.0:
+lodash.filter@^4.4.0, lodash.filter@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
 


### PR DESCRIPTION
## Status
Ready
## Description
Lets give the user a visual que that a subject has been added to a promise.

Also support unlinking them if we make mistakes

## Example | Screenshots
![subjects](https://user-images.githubusercontent.com/22854722/36935466-5ca68904-1ef8-11e8-90e9-5d3223ae246c.gif)


## Dependencies
- [Support destroy for promise subject links](https://github.com/veritus/veritus-backend/pull/76)
